### PR TITLE
PHC-WalletBuddy 1.0

### DIFF
--- a/contrib/wallettools/phc-walletbuddy/windows/README.txt
+++ b/contrib/wallettools/phc-walletbuddy/windows/README.txt
@@ -1,0 +1,39 @@
+-------------------------------------------------------------------
+PHC - PHC Wallet Buddy 1.0 - Windows - (C) 2018 Profit Hunters Coin
+-------------------------------------------------------------------
+BACKUP wallet.dat file to an external drive before you continue!
+Notice: USE THIS TOOL AT YOUR OWN RISK!
+
+
+Here are some things you can do with PHC Wallet Buddy:
+
+- Clean your AppData\PHC folder (renaming: database, txleveldb, blk0001.dat, db.log, debug.log)
+- Restore your AppData\PHC folder after cleaning (with this tool only)
+- Download/install the most recent version of phc-qt.exe
+- Download/install the most recent version of the blockchain bootstrap
+- Run wallet in "normal" or "repair wallet" mode
+
+Installing PHC Wallet Buddy 1.0:
+Step 1 - Unzip the archive or download from http://github.com/biznatchenterprises/phc/contrib/wallettools/phc-walletbuddy/windows/
+Step 2 - Copy curl.exe, this file, and phc-walletbuddy.bat in the same directory (folder) as phc-qt.exe
+
+
+Wallet chain-forked (stuck on blocks?)
+
+Step 0 - Backup your wallet! File -> Backup Wallet (selecting an external usb drive is recommended)
+Step 1 - Make sure curl.exe and stuck_wallet_fix.bat is located in the same directory (folder) as phc-qt.exe
+Step 2 - Double click (run) stuck_wallet_fix.bat
+Step 3 - You will be asked to install curl.exe to system32 type: n {ENTER}
+step 4 - You will be asked if you backed up your wallet, if you did type: y {ENTER}
+Step 5 - You will be asked to Clean PHC AppData tpe: y {ENTER}
+Step 6 - You will be asked to Download phc-qt update, if you have not already type: y {ENTER}
+Step 7 - You will be asked to Download recent bootstrap file. Type: y {ENTER}
+Step 8 - You will be asked to Load Wallet. Type: y {ENTER}
+Step 9 - Wait for your wallet to finish "importing blocks" and to connect to peers and fully sync.
+
+
+Curl not working?
+
+Step 1 - Right click on stuck_wallet_fix and click "Run as administrator"
+Step 2 - It will ask you to install curl.exe to system32. Type: y {ENTER}
+Step 3 - Run PHC Wallet Buddy again.

--- a/contrib/wallettools/phc-walletbuddy/windows/phc-walletbuddy.bat
+++ b/contrib/wallettools/phc-walletbuddy/windows/phc-walletbuddy.bat
@@ -1,0 +1,193 @@
+@echo off
+CLS
+echo -------------------------------------------------------------------
+echo PHC - Wallet Buddy 1.0 - Windows - (C) 2018 Profit Hunters Coin
+echo -------------------------------------------------------------------
+echo USE THIS TOOL AT YOUR OWN RISK!
+echo BACKUP wallet.dat file to an external drive before you continue!
+
+rem ------------------------------------------
+:startfix
+
+SET /P prompt= Install Curl to system32 (optional)? Y/N 
+
+IF "%prompt%"=="Y" GOTO :installcurl
+IF "%prompt%"=="y" GOTO :installcurl
+IF "%prompt%"=="N" GOTO :askforwalletbackup
+IF "%prompt%"=="n" GOTO :askforwalletbackup
+
+
+rem ------------------------------------------
+:installcurl
+
+echo Installing: curl to System32...
+copy %~dp0\curl.exe %SystemRoot%\System32\curl.exe
+
+GOTO :endoffix
+
+
+rem ------------------------------------------
+:askforwalletbackup
+SET /P prompt= Did you backup your wallet.dat file? Y/N 
+
+IF "%prompt%"=="Y" GOTO :askforappdataclean
+IF "%prompt%"=="y" GOTO :askforappdataclean
+IF "%prompt%"=="N" GOTO :endoffix
+IF "%prompt%"=="n" GOTO :endoffix
+
+GOTO :endoffix
+
+
+rem ------------------------------------------
+:askforappdataclean
+
+SET /P prompt= Clean PHC AppData? Y/N 
+
+IF "%prompt%"=="Y" GOTO :cleanwalletdir
+IF "%prompt%"=="y" GOTO :cleanwalletdir
+IF "%prompt%"=="N" GOTO :askforupdate
+IF "%prompt%"=="n" GOTO :askforupdate
+
+
+rem ------------------------------------------
+:cleanwalletdir
+
+echo Cleaning Wallet Datadir
+cd %userprofile%\AppData\Roaming\PHC\
+rename database database-bkp
+rename txleveldb txleveldb-bkp
+rename blk0001.dat blk0001.dat-bkp
+rename db.log db.log-bkp
+rename debug.log debug.log-bkp
+
+cd %~dp0\
+
+GOTO :askforupdate
+
+
+rem ------------------------------------------
+:askforupdate
+
+SET /P prompt= Download phc-qt.exe update (if available)? Y/N 
+
+IF "%prompt%"=="Y" GOTO :getupdate
+IF "%prompt%"=="y" GOTO :getupdate
+IF "%prompt%"=="N" GOTO :askforbootstrap
+IF "%prompt%"=="n" GOTO :askforbootstrap
+
+rem ------------------------------------------
+:getupdate
+
+cd %~dp0\
+
+echo Downloading recent version of phc-qt.exe...
+
+curl.exe -O http://profithunterscoin.com/win/phc-qt.exe
+
+GOTO :askforbootstrap
+
+
+rem ------------------------------------------
+:askforbootstrap
+
+SET /P prompt= Download bootstrap file update (if available)? Y/N 
+
+IF "%prompt%"=="Y" GOTO :downloadbootstrap
+IF "%prompt%"=="y" GOTO :downloadbootstrap
+IF "%prompt%"=="N" GOTO :askforwalletrun
+IF "%prompt%"=="n" GOTO :askforwalletrun
+
+
+rem ------------------------------------------
+:downloadbootstrap
+
+cd %userprofile%\AppData\Roaming\PHC\
+
+echo Downloading recent blockchain bootstrap...
+
+curl.exe -O http://profithunterscoin.com/bootstraps/bootstrap.dat
+
+cd %~dp0\
+
+GOTO :askforwalletrun
+
+
+rem ------------------------------------------
+:askforwalletrun
+
+SET /P prompt= Load wallet? Y/N 
+
+IF "%prompt%"=="Y" GOTO :walletrun
+IF "%prompt%"=="y" GOTO :walletrun
+IF "%prompt%"=="N" GOTO :askforwalletrepair
+IF "%prompt%"=="n" GOTO :askforwalletrepair
+
+
+rem ------------------------------------------
+:walletrun
+
+cd %~dp0\
+
+echo Loading phc-qt.exe...
+
+phc-qt.exe -loadblock=bootstrap.dat
+
+GOTO :endoffix
+
+
+rem ------------------------------------------
+:askforwalletrepair
+
+SET /P prompt= Load wallet in repair mode? Y/N 
+
+IF "%prompt%"=="Y" GOTO :walletrepair
+IF "%prompt%"=="y" GOTO :walletrepair
+IF "%prompt%"=="N" GOTO :askforrestore
+IF "%prompt%"=="n" GOTO :askforrestore
+
+
+rem ------------------------------------------
+:walletrepair
+
+cd %~dp0\
+
+echo Loading phc-qt.exe -repairwallet...
+
+phc-qt.exe -repairwallet
+
+GOTO :endoffix
+
+
+rem ------------------------------------------
+:askforrestore
+
+SET /P prompt= Restore Datadir from backup? Y/N 
+
+IF "%prompt%"=="Y" GOTO :restoreappdir
+IF "%prompt%"=="y" GOTO :restoreappdir
+IF "%prompt%"=="N" GOTO :endoffix
+IF "%prompt%"=="n" GOTO :endoffix
+
+
+rem ------------------------------------------
+:restoreappdir
+
+cd %userprofile%\AppData\Roaming\PHC\
+rename database-bkp database
+rename txleveldb-bkp txleveldb
+rename blk0001.dat-bkp blk0001.dat
+rename db.log-bkp db.log
+rename debug.log-bkp debug.log
+
+cd %~dp0\
+
+
+GOTO :endoffix
+
+
+rem ------------------------------------------
+:endoffix
+
+echo "Exiting PHC Wallet Buddy..."
+exit;
+rem ------------------------------------------

--- a/src/net.h
+++ b/src/net.h
@@ -273,7 +273,7 @@ public:
     {
         switch (banReason) {
         case BanReasonNodeMisbehaving:
-            return "node misbehabing";
+            return "node misbehaving";
         case BanReasonManuallyAdded:
             return "manually added";
         default:


### PR DESCRIPTION
- Clean your AppData\PHC folder (renaming: database, txleveldb, blk0001.dat, db.log, debug.log)
- Restore your AppData\PHC folder after cleaning (with this tool only)
- Download/install the most recent version of phc-qt.exe
- Download/install the most recent version of the blockchain bootstrap
- Run wallet in "normal" or "repair wallet" mode